### PR TITLE
Add support for tokenURI in token contracts

### DIFF
--- a/contracts/kitty/KittyBase.sol
+++ b/contracts/kitty/KittyBase.sol
@@ -222,4 +222,8 @@ contract KittyBase is KittyAccessControl {
         require(secs < cooldowns[0]);
         secondsPerBlock = secs;
     }
+
+    function _exists(uint256 _tokenId) internal view returns (bool) {
+        return kittyIndexToOwner[_tokenId] != address(0);
+    }
 }

--- a/contracts/kitty/KittyCore.sol
+++ b/contracts/kitty/KittyCore.sol
@@ -143,4 +143,9 @@ contract KittyCore is KittyMinting, URIMetadata {
             cfoAddress.send(balance - subtractFees);
         }
     }
+
+    function tokenURI(uint256 _tokenId) external view returns (string) {
+        require(_exists(_tokenId));
+        return _tokenURI(_tokenId);
+    }
 }

--- a/contracts/kitty/KittyCore.sol
+++ b/contracts/kitty/KittyCore.sol
@@ -1,11 +1,12 @@
 pragma solidity 0.4.24;
 
 import "./KittyMinting.sol";
+import "../simpleKitty/URIMetadata.sol";
 /// @title CryptoKitties: Collectible, breedable, and oh-so-adorable cats on the Ethereum blockchain.
 /// @author Axiom Zen (https://www.axiomzen.co)
 /// @dev The main CryptoKitties contract, keeps track of kittens so they don't wander around and get lost.
 
-contract KittyCore is KittyMinting {
+contract KittyCore is KittyMinting, URIMetadata {
 
     // This is the main CryptoKitties contract. In order to keep our code seperated into logical sections,
     // we've broken it up in two ways. First, we have several seperately-instantiated sibling contracts

--- a/contracts/simpleKitty/SimpleBridgeKitty.sol
+++ b/contracts/simpleKitty/SimpleBridgeKitty.sol
@@ -47,4 +47,9 @@ contract SimpleBridgeKitty is BridgeRole, SimpleKittyCore, URIMetadata {
         ownershipTokenCount[msg.sender]--;
         emit Death(_tokenId);
     }
+
+    function tokenURI(uint256 _tokenId) external view returns (string) {
+        require(_exists(_tokenId));
+        return _tokenURI(_tokenId);
+    }
 }

--- a/contracts/simpleKitty/SimpleBridgeKitty.sol
+++ b/contracts/simpleKitty/SimpleBridgeKitty.sol
@@ -2,8 +2,9 @@ pragma solidity 0.4.24;
 
 import "./SimpleKittyCore.sol";
 import "./BridgeRole.sol";
+import "./URIMetadata.sol";
 
-contract SimpleBridgeKitty is BridgeRole, SimpleKittyCore {
+contract SimpleBridgeKitty is BridgeRole, SimpleKittyCore, URIMetadata {
     event Death(uint256 kittyId);
 
     function mint(

--- a/contracts/simpleKitty/SimpleKittyBase.sol
+++ b/contracts/simpleKitty/SimpleKittyBase.sol
@@ -138,4 +138,8 @@ contract SimpleKittyBase {
 
         return _tokenId;
     }
+
+    function _exists(uint256 _tokenId) internal view returns (bool) {
+        return kittyIndexToOwner[_tokenId] != address(0);
+    }
 }

--- a/contracts/simpleKitty/URIMetadata.sol
+++ b/contracts/simpleKitty/URIMetadata.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.4.24;
 
 contract URIMetadata {
-    function tokenURI(uint256 _tokenId) external view returns (string) {
+    function _tokenURI(uint256 _tokenId) internal pure returns (string) {
         return strConcat("https://api.cryptokitties.co/kitties/", uintToString(_tokenId));
     }
 

--- a/contracts/simpleKitty/URIMetadata.sol
+++ b/contracts/simpleKitty/URIMetadata.sol
@@ -1,0 +1,40 @@
+pragma solidity 0.4.24;
+
+contract URIMetadata {
+    function tokenURI(uint256 _tokenId) external view returns (string) {
+        return strConcat("https://api.cryptokitties.co/kitties/", uintToString(_tokenId));
+    }
+
+    function uintToString(uint256 i) internal pure returns (string) {
+        if (i == 0) return "0";
+        uint256 j = i;
+        uint256 length;
+        while (j != 0) {
+            length++;
+            j /= 10;
+        }
+        bytes memory bstr = new bytes(length);
+        uint256 k = length - 1;
+        while (i != 0) {
+            bstr[k--] = bytes1(48 + (i % 10));
+            i /= 10;
+        }
+        return string(bstr);
+    }
+
+    function strConcat(string _a, string _b) internal pure returns (string) {
+        bytes memory _ba = bytes(_a);
+        bytes memory _bb = bytes(_b);
+        string memory ab = new string(_ba.length + _bb.length);
+        bytes memory bab = bytes(ab);
+        uint256 k = 0;
+        uint256 i = 0;
+        for (i = 0; i < _ba.length; i++) {
+            bab[k++] = _ba[i];
+        }
+        for (i = 0; i < _bb.length; i++) {
+            bab[k++] = _bb[i];
+        }
+        return string(bab);
+    }
+}

--- a/test/simpleBridgeKitty.test.js
+++ b/test/simpleBridgeKitty.test.js
@@ -384,4 +384,11 @@ contract('SimpleBridgeKitty', accounts => {
       })
     })
   })
+  describe('tokenURI', () => {
+    it('should return string URI of token', async () => {
+      expect(await token.tokenURI(1)).to.be.equal('https://api.cryptokitties.co/kitties/1')
+      expect(await token.tokenURI(12345)).to.be.equal('https://api.cryptokitties.co/kitties/12345')
+      expect(await token.tokenURI(1714022)).to.be.equal('https://api.cryptokitties.co/kitties/1714022')
+    })
+  })
 })

--- a/test/simpleBridgeKitty.test.js
+++ b/test/simpleBridgeKitty.test.js
@@ -386,8 +386,62 @@ contract('SimpleBridgeKitty', accounts => {
   })
   describe('tokenURI', () => {
     it('should return string URI of token', async () => {
+      // should fail if token does not exists
+      await expectRevert.unspecified(token.tokenURI(1))
+
+      await token.mint(
+        1,
+        isReady,
+        cooldownIndex,
+        nextActionAt,
+        siringWithId,
+        birthTime,
+        matronId,
+        sireId,
+        generation,
+        genes,
+        user,
+        { from: owner }
+      )
+
       expect(await token.tokenURI(1)).to.be.equal('https://api.cryptokitties.co/kitties/1')
+
+      await expectRevert.unspecified(token.tokenURI(12345))
+
+      await token.mint(
+        12345,
+        isReady,
+        cooldownIndex,
+        nextActionAt,
+        siringWithId,
+        birthTime,
+        matronId,
+        sireId,
+        generation,
+        genes,
+        user,
+        { from: owner }
+      )
+
       expect(await token.tokenURI(12345)).to.be.equal('https://api.cryptokitties.co/kitties/12345')
+
+      await expectRevert.unspecified(token.tokenURI(1714022))
+
+      await token.mint(
+        1714022,
+        isReady,
+        cooldownIndex,
+        nextActionAt,
+        siringWithId,
+        birthTime,
+        matronId,
+        sireId,
+        generation,
+        genes,
+        user,
+        { from: owner }
+      )
+
       expect(await token.tokenURI(1714022)).to.be.equal('https://api.cryptokitties.co/kitties/1714022')
     })
   })


### PR DESCRIPTION
Closes #7 

Example of KittyCore deployed in Kovan with some minted tokens: https://blockscout.com/eth/kovan/address/0xe0840422d1aa293162b7811feca3dd1a44912f27 